### PR TITLE
Apply rule MigrateOldControllerToNew in package Compatibility56

### DIFF
--- a/Controller/Backend/Mailcatcher.php
+++ b/Controller/Backend/Mailcatcher.php
@@ -1,5 +1,9 @@
 <?php
 
+
+namespace FroshMailCatcher\Controller\Backend;
+
+use Shopware_Controllers_Backend_Application;
 use Doctrine\ORM\AbstractQuery;
 use FroshMailCatcher\Models\Attachment;
 use FroshMailCatcher\Models\Mails;
@@ -7,7 +11,7 @@ use FroshMailCatcher\Models\Mails;
 /**
  * Class Shopware_Controllers_Backend_Mailcatcher
  */
-class Shopware_Controllers_Backend_Mailcatcher extends Shopware_Controllers_Backend_Application implements \Shopware\Components\CSRFWhitelistAware
+class Mailcatcher extends Shopware_Controllers_Backend_Application implements \Shopware\Components\CSRFWhitelistAware
 {
     /**
      * @var string

--- a/Resources/services.xml
+++ b/Resources/services.xml
@@ -25,5 +25,9 @@
             <argument type="string">%frosh_mail_catcher.plugin_dir%</argument>
             <tag name="shopware.event_subscriber"/>
         </service>
+
+        <service id="FroshMailCatcher\Controller\Backend\Mailcatcher">
+            <tag name="shopware.controller" module="backend" controller="mailcatcher"/>
+        </service>
     </services>
 </container>


### PR DESCRIPTION
Hey!

I have applied rule MigrateOldControllerToNew for you, to make it better compatible with Shopware 5.6!
FroshAutoFixer will resolve any conflicts with this PR as long as you don't alter it yourself. You can also trigger a rebase manually by commenting @FroshAutoFixer rebase.