### PR TITLE
Compatibility with Shopware 5.7

### DIFF
--- a/Resources/services.xml
+++ b/Resources/services.xml
@@ -12,7 +12,7 @@
         <service id="mailtransport_factory" class="FroshMailCatcher\Components\MailFactory">
             <argument type="service" id="frosh_mail_catcher.components.database_mail_transport" />
         </service>
-        <service id="frosh_mail_catcher.components.database_mail_transport" class="FroshMailCatcher\Components\DatabaseMailTransport">
+        <service id="frosh_mail_catcher.components.database_mail_transport" class="FroshMailCatcher\Components\DatabaseMailTransport" public="true">
             <argument type="service" id="dbal_connection" />
         </service>
 


### PR DESCRIPTION
This service needs to be public in order to work with Shopware 5.7. It is accessed via `Shopware()->Container()` here: https://github.com/FriendsOfShopware/FroshMailCatcher/blob/master/Components/MailFactory.php#L15

Not sure if one could modify the MailFactory in order to avoid making this service public.