### PR TITLE
Method getPlainBodyText, getPlainBody dont exsist in class Zend_Mail

### DIFF
--- a/Components/DatabaseMailTransport.php
+++ b/Components/DatabaseMailTransport.php
@@ -51,13 +51,15 @@ class DatabaseMailTransport extends \Zend_Mail_Transport_Abstract
             }
         }
 
+        $bodyPlainText = ($this->_mail->getBodyText() != false) ? $this->_mail->getBodyText()->getRawContent() : "";
+        $bodyHtml = ($this->_mail->getBodyHtml() != false) ? $this->_mail->getBodyHtml()->getRawContent() : ""; 
         $this->connection->insert('s_plugin_mailcatcher', [
             'created' => date('Y-m-d H:i:s'),
             'senderAddress' => $this->_mail->getFrom(),
             'receiverAddress' => implode(',', $this->_mail->getRecipients()),
             'subject' => iconv_mime_decode($this->_mail->getSubject()),
-            'bodyText' => $this->_mail->getPlainBodyText(),
-            'bodyHtml' => $this->_mail->getPlainBody(),
+            'bodyText' => $bodyPlainText,
+            'bodyHtml' => $bodyHtml,
         ]);
 
         $insertId = $this->connection->lastInsertId();


### PR DESCRIPTION
Zend_Mail is the type of property _mail of class Zend_Mail_Transport_Abstract.
FroshMailCatcher\Components\DatabaseMailTransport extends this class and therefore not use these methods on $this->_mail, as it causes an error when calling the send method of an object of type Zend_Mail passing the service mailtransport of shopware 5.7.18 as the argument.